### PR TITLE
Backward compatible deferencing of hashes

### DIFF
--- a/lib/Bio/Roary/AnnotateGroups.pm
+++ b/lib/Bio/Roary/AnnotateGroups.pm
@@ -116,7 +116,7 @@ sub _build__ids_to_verbose_stats {
         my @matches_hash = fgrep { /ID=/i } @{ $self->_filtered_gff_files };
         my @matches;
         foreach my $m ( @matches_hash ){
-            push( @matches, values $m->{matches} );
+            push( @matches, values %{$m->{matches}} );
         }
         # chomp @matches;
         


### PR DESCRIPTION
Perl versions prior to 5.14 raise a compilation error
when an hash has not been de-referenced

Should fix issue #128