### PR TITLE
revert core tree generation

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.2.5
+version = 3.2.6
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
+++ b/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
@@ -149,13 +149,6 @@ sub run {
       );
       $seg->run();
 	  
-      my $core_tree = Bio::Roary::External::Fasttree->new(
-	          input_file => 'core_gene_alignment.aln',
-	          verbose    => $self->verbose,
-	          logger     => $self->logger
-	      );
-	  $core_tree->run();
-	
       # Cleanup intermediate multifasta files
       if($self->dont_delete_files == 0)
       {

--- a/t/Bio/Roary/CommandLine/Roary.t
+++ b/t/Bio/Roary/CommandLine/Roary.t
@@ -129,8 +129,6 @@ SKIP:
     mock_execute_script_and_check_output( $script_name, \%scripts_and_expected_files );
 
     ok( -e 'core_gene_alignment.aln', 'Core gene alignment exists' );
-	ok( -e 'core_gene_alignment.aln.newick', 'core gene newick tree exists');
-
 }
 
 SKIP:


### PR DESCRIPTION
Ram requirement is too high for generating core trees straight off with fasttree, removed.