### PR TITLE
Check dependancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ ftp://ftp.sanger.ac.uk/pub/pathogens/pathogens-vm/pathogens-vm.latest.ova
 More importantly though, if your trying to do bioinformatics on Windows, your not going to get very far and you should seriously consider upgrading to Linux.
 
 ##Other versions of Linux
-If none of the above options work, you'll have to install the depedancies from source or from your distributions packaging system.  You should probably ask your system administrator for assistance if you havent done this kind of thing before.
+If none of the above options work, you'll have to install the depedancies from source or from your distributions packaging system.  You should ask your system administrator for assistance if you havent done this kind of thing before.
 
 ### Ancient versions of perl
 The code will not work with perl 5.8 or below (pre-modern perl). 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.2.8
+version = 3.2.9
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/CommandLine/CreatePanGenome.pm
+++ b/lib/Bio/Roary/CommandLine/CreatePanGenome.pm
@@ -43,6 +43,7 @@ Options: -p INT    number of threads [1]
          -qc       generate QC report with Kraken
          -k STR    path to Kraken database for QC, use with -qc
          -w        print version and exit
+		 -a        check dependancies and exit
          -h        this help message
 
 Example: Quickly generate a core gene alignment using 16 threads

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -110,8 +110,8 @@ sub BUILD {
     }
 
     $self->help($help) if ( defined($help) );
-    if ( @{ $self->args } == 0 ) {
-        $self->logger->error("Error: You need to provide a GFF file");
+    if ( @{ $self->args } <= 2 ) {
+        $self->logger->error("Error: You need to provide at least 2 files to build a pan genome");
         die $self->usage_text;
     }
     $self->output_filename($output_filename)   if ( defined($output_filename) );

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -16,6 +16,7 @@ use Bio::Roary;
 use Bio::Roary::PrepareInputFiles;
 use Bio::Roary::QC::Report;
 use Bio::Roary::ReformatInputGFFs;
+use Bio::Roary::External::CheckTools;
 use File::Which;
 use File::Path qw(make_path);
 use Cwd  qw(abs_path getcwd); 
@@ -62,7 +63,7 @@ sub BUILD {
         $job_runner,            $makeblastdb_exec,  $mcxdeblast_exec,         $mcl_exec,      $blastp_exec,
         $apply_unknowns_filter, $cpus,              $output_multifasta_files, $verbose_stats, $translation_table,
         $run_qc,                $core_definition,   $help,                    $kraken_db,     $cmd_version,
-        $mafft,                 $output_directory,
+        $mafft,                 $output_directory,  $check_dependancies,
     );
 
     GetOptionsFromArray(
@@ -91,6 +92,7 @@ sub BUILD {
         'n|mafft'                   => \$mafft,
         'k|kraken_db=s'             => \$kraken_db,
         'w|version'                 => \$cmd_version,
+		'a|check_dependancies'      => \$check_dependancies,
         'h|help'                    => \$help,
     );
 
@@ -99,6 +101,13 @@ sub BUILD {
         print $self->_version();
         exit();
     }
+	
+	if($check_dependancies)
+	{
+	    my $check_tools = Bio::Roary::External::CheckTools->new();
+	    $check_tools->check_all_tools;
+		exit();
+	}
 
     print "\nPlease cite Roary if you use any of the results it produces:
     Andrew J. Page, Carla A. Cummins, Martin Hunt, Vanessa K. Wong, Sandra Reuter, Matthew T. G. Holden, Maria Fookes, Daniel Falush, Jacqueline A. Keane, Julian Parkhill (2015), \"Roary: Rapid large-scale prokaryote pan genome analysis\", Bioinformatics,
@@ -110,7 +119,7 @@ sub BUILD {
     }
 
     $self->help($help) if ( defined($help) );
-    if ( @{ $self->args } <= 2 ) {
+    if ( @{ $self->args } < 2 ) {
         $self->logger->error("Error: You need to provide at least 2 files to build a pan genome");
         die $self->usage_text;
     }
@@ -303,6 +312,7 @@ Options: -p INT    number of threads [1]
          -qc       generate QC report with Kraken
          -k STR    path to Kraken database for QC, use with -qc
          -w        print version and exit
+		 -a        check dependancies and exit
          -h        this help message
 
 Example: Quickly generate a core gene alignment using 8 threads

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -99,14 +99,14 @@ sub BUILD {
     $self->version($cmd_version) if ( defined($cmd_version) );
     if ( $self->version ) {
         print $self->_version();
-        exit();
+        die();
     }
 	
 	if($check_dependancies)
 	{
 	    my $check_tools = Bio::Roary::External::CheckTools->new();
 	    $check_tools->check_all_tools;
-		exit();
+		die();
 	}
 
     print "\nPlease cite Roary if you use any of the results it produces:

--- a/lib/Bio/Roary/External/CheckTools.pm
+++ b/lib/Bio/Roary/External/CheckTools.pm
@@ -59,12 +59,12 @@ my %tools = (
   'prank' => {
     GETVER  => "prank -version | grep PRANK",
     REGEXP  => qr/PRANK v.(\d+)/,
-    NEEDED  => 0,
+    NEEDED  => 1,
   },
   'mafft' => {
     GETVER  => "mafft --version < /dev/null 2>&1",
     REGEXP  => qr/v($BIDEC) /,
-    NEEDED  => 0,
+    NEEDED  => 1,
   },
   'cdhit' => {
     GETVER  => "cdhit -h | grep 'CD-HIT version'",

--- a/lib/Bio/Roary/External/CheckTools.pm
+++ b/lib/Bio/Roary/External/CheckTools.pm
@@ -1,0 +1,141 @@
+package Bio::Roary::External::CheckTools;
+
+# ABSTRACT: Check external executables are available and are the correct version
+
+=head1 SYNOPSIS
+Functionality borrowed from PROKKA by Torsten Seemann.
+Check external executables are available and are the correct version
+
+   use Bio::Roary::External::CheckTools;
+   
+   my $obj = Bio::Roary::External::CheckTools->new();
+   $obj->check_all_tools;
+
+=cut
+
+use Moose;
+use File::Spec;
+use Log::Log4perl qw(:easy);
+has 'logger'                  => ( is => 'ro', lazy => 1, builder => '_build_logger');
+
+sub _build_logger
+{
+    my ($self) = @_;
+    Log::Log4perl->easy_init($DEBUG);
+    my $logger = get_logger();
+    return $logger;
+}
+
+my $BIDEC = '(\d+\.\d+)';  # pattern of NN.NN for versions that can be compared
+
+my %tools = (
+  'parallel' => {
+    GETVER  => "parallel --version | grep '^GNU parallel 2'",
+    REGEXP  => qr/GNU parallel (\d+)/,
+    MINVER  => "20130422",
+    NEEDED  => 1,
+  },
+  'blastp' => {
+    GETVER  => "blastp -version",
+    REGEXP  => qr/blastp:\s+(\d+\.\d+\.\d+)/,
+    NEEDED  => 1,
+  },
+  'makeblastdb' => {
+    GETVER  => "makeblastdb -version",
+    REGEXP  => qr/makeblastdb:\s+(\d+\.\d+\.\d+)/,
+    NEEDED  => 1,
+  },
+  'mcl' => {
+    GETVER  => "mcl --version | head -n 1",
+    REGEXP  => qr/(\d+\-\d+)/,
+    NEEDED  => 1,
+  },
+  'bedtools' => {
+    GETVER  => "bedtools --version",
+    REGEXP  => qr/bedtools v($BIDEC)/,
+    MINVER  => "2.2",
+    NEEDED  => 1,
+  },
+  'prank' => {
+    GETVER  => "prank -version | grep PRANK",
+    REGEXP  => qr/PRANK v.(\d+)/,
+    NEEDED  => 0,
+  },
+  'mafft' => {
+    GETVER  => "mafft --version < /dev/null 2>&1",
+    REGEXP  => qr/v($BIDEC) /,
+    NEEDED  => 0,
+  },
+  'cdhit' => {
+    GETVER  => "cdhit -h | grep 'CD-HIT version'",
+    REGEXP  => qr/version ($BIDEC) /,
+    MINVER  => "4.6",
+    NEEDED  => 0,
+  },
+  'cd-hit' => {
+    GETVER  => "cd-hit -h | grep 'CD-HIT version'",
+    REGEXP  => qr/version ($BIDEC) /,
+    MINVER  => "4.6",
+    NEEDED  => 0,
+  },
+  
+  # now just the standard unix tools we need
+  'grep'    => { NEEDED=>1 },
+  'sed'     => { NEEDED=>1 },
+  'awk'     => { NEEDED=>1 },
+);  
+
+sub check_tool {
+  my($self,$toolname) = @_;
+  my $t = $tools{$toolname};
+  my $fp = $self->find_exe($toolname);
+  $self->logger->error("Can't find required '$toolname' in your \$PATH") if !$fp and $t->{NEEDED};
+  $self->logger->error("Optional tool '$toolname' not found in your \$PATH") if !$fp and ! $t->{NEEDED};
+  
+  if ($fp) {
+    $t->{HAVE} = $fp;
+    $self->logger->warn("Looking for '$toolname' - found $fp");
+    if ($t->{GETVER}) {
+      my($s) = qx($t->{GETVER});
+      if (defined $s) {
+        $s =~ $t->{REGEXP};
+        $t->{VERSION} = $1 if defined $1;
+        $self->logger->warn("Determined $toolname version is $t->{VERSION}");
+        if (defined $t->{MINVER} and $t->{VERSION} < $t->{MINVER}) {
+          $self->logger->error("Roary needs $toolname $t->{MINVER} or higher. Please upgrade and try again.");
+        }
+        if (defined $t->{MAXVER} and $t->{VERSION} > $t->{MAXVER}) {
+          $self->logger->error("Roary needs a version of $toolname between $t->{MINVER} and $t->{MAXVER}. Please downgrade and try again."); 
+        }
+      }
+      else {
+        $self->logger->error("Could not determine version of $toolname - please install version",
+            $t->{MINVER}, "or higher");  # FIXME: or less <= MAXVER if given
+      }
+    }
+  }
+}
+
+sub check_all_tools {
+  my($self) = @_;
+  $ENV{"GREP_OPTIONS"} = '';  # --colour => version grep fails (Issue #117)
+  for my $toolname (sort keys %tools) {
+    $self->check_tool($toolname);
+  }
+  return $self;
+}
+
+sub find_exe {
+  my($self,$bin) =  @_;	
+  for my $dir (File::Spec->path) {
+    my $exe = File::Spec->catfile($dir, $bin);
+    return $exe if -x $exe; 
+  }
+  return;
+}
+
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Bio/Roary/External/IterativeCdhit.pm
+++ b/lib/Bio/Roary/External/IterativeCdhit.pm
@@ -41,7 +41,7 @@ sub _build__memory_required_in_mb {
         # Convert to mb
         $memory_required = int( $memory_required / 1000000 );
 
-        # Triple memory for worst case senario
+        # Pentuple memory for worst case senario
         $memory_required *= 5;
         $memory_required = 2000 if ( $memory_required < 2000 );
     }

--- a/t/00_requires_external.t
+++ b/t/00_requires_external.t
@@ -2,7 +2,7 @@
 
 use Test::Most;
 use FindBin;
-plan tests => 7;
+plan tests => 8;
 bail_on_fail if 0;
 use Env::Path 'PATH';
 

--- a/t/00_requires_external.t
+++ b/t/00_requires_external.t
@@ -16,5 +16,5 @@ for my $dir ($BINDIR, $FindBin::RealBin) {
      }
 }
 
-ok(scalar PATH->Whence($_), "$_ in PATH") for qw(blastp makeblastdb mcl mcxdeblast bedtools prank parallel);
+ok(scalar PATH->Whence($_), "$_ in PATH") for qw(blastp makeblastdb mcl mcxdeblast bedtools prank parallel mafft);
 

--- a/t/Bio/Roary/CommandLine/Roary.t
+++ b/t/Bio/Roary/CommandLine/Roary.t
@@ -82,6 +82,7 @@ for my $filename ( ( 'query_1.gff.proteome.faa', 'query_2.gff.proteome.faa', 'qu
         "content of proteome $filename as expected" );
 }
 
+stderr_should_have($script_name,'-a', 'Looking for');
 
 my $current_cwd = getcwd();
 stderr_should_have($script_name,'-v --output_directory t/data/directory_which_doesnt_exist t/data/real_data_1.gff t/data/real_data_2.gff', 'Output directory created');

--- a/t/Bio/Roary/External/CheckTools.t
+++ b/t/Bio/Roary/External/CheckTools.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+use Cwd;
+use Test::Output;
+
+BEGIN { unshift( @INC, './lib' ) }
+
+BEGIN {
+    use Test::Most;
+    use_ok('Bio::Roary::External::CheckTools');
+}
+ok( my $check_tools = Bio::Roary::External::CheckTools->new(), 'initialise checking for tools' );
+for my $tool ( ( 'parallel', 'blastp', 'makeblastdb', 'mcl', 'bedtools', 'prank', 'mafft', 'grep', 'sed', 'awk', ) ) {
+    my $pattern = "Looking for '$tool' - found ";
+    stderr_like { $check_tools->check_tool($tool); } qr/$pattern/, "Check for $tool";
+}
+
+stderr_like { $check_tools->check_all_tools; } qr/Looking for /, "Check for all tools";
+1;
+
+done_testing();


### PR DESCRIPTION
Addresses the following issues:
https://github.com/sanger-pathogens/Roary/issues/175
https://github.com/sanger-pathogens/Roary/issues/168
https://github.com/sanger-pathogens/Roary/issues/171

New option to report on dependancies to make debugging easier.
Check for at least 2 input files.
Make mafft a required executable