### PR TITLE
Use lsf for gene alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ export PERL5LIB=$PERL5LIB:$HOME/Roary-x.x.x/lib
 ###Install perl dependancies
 
 ```
-sudo cpanm  Array::Utils Bio::Perl Exception::Class File::Basename File::Copy File::Find::Rule File::Grep File::Path File::Slurp::Tiny File::Spec File::Temp File::Which FindBin Getopt::Long Graph Graph::Writer::Dot List::Util Log::Log4perl Moose Moose::Role Text::CSV
+sudo cpanm  Array::Utils Bio::Perl Exception::Class File::Basename File::Copy File::Find::Rule File::Grep File::Path File::Slurper File::Spec File::Temp File::Which FindBin Getopt::Long Graph Graph::Writer::Dot List::Util Log::Log4perl Moose Moose::Role Text::CSV
 ```
 
 ##Virtual Machine - OSX/Linux/Windows

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-#Website
-(http://sanger-pathogens.github.io/Roary)
-
 #Roary the pan genome pipeline
+For instructions on how to use the software, the input format and output formats, please see [the Roary website](http://sanger-pathogens.github.io/Roary).
 
 [![Build Status](https://travis-ci.org/sanger-pathogens/Roary.svg?branch=master)](https://travis-ci.org/sanger-pathogens/Roary)
 
@@ -11,47 +9,31 @@ Roary is a high speed stand alone pan genome pipeline, which takes annotated ass
     "Roary: Rapid large-scale prokaryote pan genome analysis",
     Andrew J. Page, Carla A. Cummins, Martin Hunt, Vanessa K. Wong, Sandra Reuter, Matthew T. G. Holden, Maria Fookes, Daniel Falush, Jacqueline A. Keane, Julian Parkhill,
     Bioinformatics, (2015). doi: http://dx.doi.org/10.1093/bioinformatics/btv421
-
-##Read the paper
 [Roary: Rapid large-scale prokaryote pan genome analysis](http://dx.doi.org/10.1093/bioinformatics/btv421)
-
-##Input
-Roary takes annotated assemblies as input in GFF3 format, such as those produced by [Prokka](https://github.com/tseemann/prokka/).  You should try and give each genome a unique prefix (--prefix option in prokka) so that the IDs are globally unique. Roary will fix any clashes, but it will be less intuitive than if you do it yourself.  Files downloaded from GenBank should already have unique IDs.
-
 
 # Installation
 Theres are a number of dependancies required for Roary, with instructions specific to the type of system you have:
 * Ubuntu/Debian
 * CentOS/RedHat
 * Homebrew/Linuxbrew - OSX/Linux
-* Bundled binaries - OSX/Linux
+* Installing from source - OSX/Linux
 * Virtual Machine - OSX/Linux/Windows
 
+If the installation fails please contact your system administrator. If you encounter a bug please let us know by emailing roary@sanger.ac.uk .
+
 ##Ubuntu/Debian
-Assuming you have root on your system, all the dependancies can be installed using apt and cpanm (only tested on Ubuntu 14.04).
+All the dependancies can be installed using apt and cpanm (tested on Ubuntu 14.04). Root permissions are required.
 
 ```
 sudo apt-get install bedtools cd-hit ncbi-blast+ mcl parallel cpanminus prank mafft exonerate fasttree
 sudo cpanm -f Bio::Roary
 ```   
 
+###Ubuntu 12.04
+Some of the software versions in apt are quite old so follow the instructions for [LinuxBrew](http://brew.sh/linuxbrew/) below.
+
 ##CentOS/RedHat
-To install the dependancies, the easiest way is through [linuxbrew](http://brew.sh/linuxbrew/), following the instructions for Fedora. Alternatively try the ./install_dependencies.sh script. 
-
-```
-brew tap homebrew/science
-brew install bedtools cd-hit blast mcl parallel prank mafft exonerate fasttree cpanm
-sudo cpanm -f Bio::Roary
-```
-
-
-###Older versions of Ubuntu/Debian (12.04 and below)
-Follow the instructions for LinuxBrew. 
-
-Alternatively, run this script from BASH, then copy and paste the last few lines into your BASH profile, as per the instructions.  Not all the packages Roary requires are available on older versions of Ubuntu/Debian or the versions dont support features Roary requires.  So this script will build them from source in the current working directory and install missing dependancies using apt and cpanm. This script is run automatically by our [continous integration server](https://travis-ci.org/andrewjpage/Roary) which runs on Ubuntu 12.04.
-```
-./install_dependencies.sh
-```
+To install the dependancies, the easiest way is to install [LinuxBrew](http://brew.sh/linuxbrew/) using the steps for Fedora, then follow the steps below for installing Roary on LinuxBrew.
 
 ##Homebrew/Linuxbrew - OSX/Linux
 Assuming you have [homebrew](http://brew.sh/) (OSX) or [linuxbrew](http://brew.sh/linuxbrew/) (Linux) setup and installed on your system:
@@ -62,14 +44,17 @@ brew install bedtools cd-hit blast mcl parallel prank mafft exonerate fasttree c
 sudo cpanm -f Bio::Roary
 ```
 
-##Bundled binaries - OSX/Linux
-As a last resort we have included precompiled binaries of the dependancies. They might work, if they dont, you'll need to install the dependancies from source. If your running an ancient version of Linux or OSX (more than 3 years since release) its unlikely to work.
+##Virtual Machine - OSX/Linux/Windows
+Roary wont run natively on Windows but we have created virtual machine which has all of the software setup, including Prokka, along with the test datasets from the paper. It is based on [Bio-Linux 8](http://environmentalomics.org/bio-linux/).  You need to first install [VirtualBox](https://www.virtualbox.org/), then load the virtual machine, using the 'File -> Import Appliance' menu option. The root password is 'manager'.
 
-###Download
-Download the latest software from 
-https://github.com/sanger-pathogens/Roary/tarball/master
+ftp://ftp.sanger.ac.uk/pub/pathogens/pathogens-vm/pathogens-vm.latest.ova
 
-###Extract
+More importantly though, if your trying to do bioinformatics on Windows, your not going to get very far and you should seriously consider upgrading to Linux.
+
+##Installing from source (advanced Linux users only)
+As a last resort you can install everything from source. This is for users with advanced Linux skills and we do not provide any support with this method since you have the skills to figure things out.
+Download the latest software from (https://github.com/sanger-pathogens/Roary/tarball/master).
+
 Choose somewhere to put it, for example in your home directory (no root access required):
 
 ```
@@ -78,32 +63,24 @@ tar zxvf sanger-pathogens-Roary-xxxxxx.tar.gz
 ls Roary-*
 ```
 
-###Add to your Environment
 Add the following lines to your $HOME/.bashrc file, or to /etc/profile.d/roary.sh to make it available to all users:
 
 ```
 export PATH=$PATH:$HOME/Roary-x.x.x/bin
 export PERL5LIB=$PERL5LIB:$HOME/Roary-x.x.x/lib
 ```
-
-###Install perl dependancies
+Install the perl dependancies:
 
 ```
 sudo cpanm  Array::Utils Bio::Perl Exception::Class File::Basename File::Copy File::Find::Rule File::Grep File::Path File::Slurper File::Spec File::Temp File::Which FindBin Getopt::Long Graph Graph::Writer::Dot List::Util Log::Log4perl Moose Moose::Role Text::CSV
 ```
+Install the external dependances either from source or from your packaging system:
+```
+bedtools cd-hit blast mcl GNUparallel prank mafft exonerate fasttree
+```
 
-##Virtual Machine - OSX/Linux/Windows
-Roary wont run natively on Windows but we have created virtual machine which has all of the software setup, including Prokka, along with the test datasets from the paper. It is based on [Bio-Linux 8](http://environmentalomics.org/bio-linux/).  You need to first install [VirtualBox](https://www.virtualbox.org/), then load the virtual machine, using the 'File -> Import Appliance' menu option. The root password is 'manager'.
-
-ftp://ftp.sanger.ac.uk/pub/pathogens/pathogens-vm/pathogens-vm.latest.ova
-
-More importantly though, if your trying to do bioinformatics on Windows, your not going to get very far and you should seriously consider upgrading to Linux.
-
-##Other versions of Linux
-If none of the above options work, you'll have to install the depedancies from source or from your distributions packaging system.  You should ask your system administrator for assistance if you havent done this kind of thing before.
-
-### Ancient versions of perl
-The code will not work with perl 5.8 or below (pre-modern perl). 
+## Ancient systems and versions of perl
+The code will not work with perl 5.8 or below (pre-modern perl). If your running a very old verison of Linux, your also in trouble.
 
 #Versions of software we test against
 * Perl 5.10, 5.14, 5.16, 5.18, 5.20

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.3.2
+version = 3.3.3
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/CommandLine/RoaryCoreAlignment.pm
+++ b/lib/Bio/Roary/CommandLine/RoaryCoreAlignment.pm
@@ -130,6 +130,7 @@ Options: -o STR    output filename [core_gene_alignment.aln]
          -cd FLOAT percentage of isolates a gene must be in to be core [99]
          -m STR    directory containing gene multi-FASTAs [pan_genome_sequences]
          -s STR    gene presence and absence spreadsheet [gene_presence_absence.csv]
+         -z        dont delete intermediate files
          -v        verbose output to STDOUT
          -h        this help message
 

--- a/lib/Bio/Roary/CommandLine/RoaryCoreAlignment.pm
+++ b/lib/Bio/Roary/CommandLine/RoaryCoreAlignment.pm
@@ -12,6 +12,7 @@ Take in the group statistics spreadsheet and the location of the gene multifasta
 use Moose;
 use Getopt::Long qw(GetOptionsFromArray);
 use Cwd 'abs_path';
+use File::Path qw(remove_tree);
 use Bio::Roary::ExtractCoreGenesFromSpreadsheet;
 use Bio::Roary::LookupGeneFiles;
 use Bio::Roary::MergeMultifastaAlignments;
@@ -25,13 +26,14 @@ has 'multifasta_base_directory' => ( is => 'rw', isa => 'Str', default => 'pan_g
 has 'spreadsheet_filename'      => ( is => 'rw', isa => 'Str', default => 'gene_presence_absence.csv' );
 has 'output_filename'           => ( is => 'rw', isa => 'Str', default => 'core_gene_alignment.aln' );
 has 'core_definition'           => ( is => 'rw', isa => 'Num', default => 0.99 );
+has 'dont_delete_files'         => ( is => 'rw', isa => 'Bool', default => 0 );
 has '_error_message'            => ( is => 'rw', isa => 'Str' );
 has 'verbose'                   => ( is => 'rw', isa => 'Bool', default => 0 );
 
 sub BUILD {
     my ($self) = @_;
 
-    my ( $multifasta_base_directory, $spreadsheet_filename, $output_filename, $core_definition,$verbose,  $help, $mafft );
+    my ( $multifasta_base_directory, $spreadsheet_filename, $output_filename, $core_definition,$verbose,  $help, $mafft, $dont_delete_files );
 
     GetOptionsFromArray(
         $self->args,
@@ -39,6 +41,7 @@ sub BUILD {
         's|spreadsheet_filename=s'      => \$spreadsheet_filename,
         'o|output_filename=s'           => \$output_filename,
         'cd|core_definition=f'          => \$core_definition,
+        'z|dont_delete_files'           => \$dont_delete_files,
 		'v|verbose'                     => \$verbose,
         'h|help'                        => \$help,
     );
@@ -76,6 +79,8 @@ sub BUILD {
 			$self->core_definition( $core_definition );
 		}
 	}
+    $self->dont_delete_files($dont_delete_files) if ( defined($dont_delete_files) );
+    
 }
 
 sub run {
@@ -107,6 +112,11 @@ sub run {
 	  sample_names_to_genes => $core_genes_obj->sample_names_to_genes
     );
     $merge_alignments_obj->merge_files;
+    
+    if($self->dont_delete_files == 0)
+    {
+      remove_tree('pan_genome_sequences');
+    }
 }
 
 sub usage_text {

--- a/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
+++ b/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
@@ -134,30 +134,36 @@ sub run {
         remove_tree('split_groups');
     }
 
-
     if($self->output_multifasta_files == 1)
     {
-		print "Aligning each cluster\n" if($self->verbose);
+	  print "Aligning each cluster\n" if($self->verbose);
       my $output_gene_files = $self->_find_input_files;
       my $seg = Bio::Roary::External::GeneAlignmentFromNucleotides->new(
         fasta_files         => $output_gene_files,
-        job_runner          => $self->job_runner,
+        job_runner          => $self->_is_lsf_job_runner_available ? 'LSF' : $self->job_runner,
         translation_table   => $self->translation_table,
         core_definition     => $self->core_definition,
         cpus                => $self->cpus,
 		verbose             => $self->verbose,
 		mafft               => $self->mafft,
+        dont_delete_files   => $self->dont_delete_files,
       );
       $seg->run();
-	  
-      # Cleanup intermediate multifasta files
-      if($self->dont_delete_files == 0)
-      {
-        remove_tree('pan_genome_sequences');
-      }
     }
-     
+}
 
+sub _is_lsf_job_runner_available
+{
+    my ($self) = @_;
+    my $rc = eval "require Bio::Roary::JobRunner::LSF; 1;";
+    if(defined($rc) && $rc == 1)
+    {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 sub _find_input_files

--- a/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
+++ b/lib/Bio/Roary/CommandLine/RoaryPostAnalysis.pm
@@ -108,9 +108,10 @@ sub run {
         die $self->usage_text;
     }
 
+    my $input_files = $self->_read_file_into_array($self->input_files);
     my $obj = Bio::Roary::PostAnalysis->new(
       fasta_files                     =>  $self->_read_file_into_array($self->fasta_files) ,
-      input_files                     =>  $self->_read_file_into_array($self->input_files) ,
+      input_files                     =>  $input_files ,
       output_filename                 =>  $self->output_filename            ,
       output_pan_geneome_filename     =>  $self->output_pan_geneome_filename,
       output_statistics_filename      =>  $self->output_statistics_filename ,
@@ -147,6 +148,7 @@ sub run {
 		verbose             => $self->verbose,
 		mafft               => $self->mafft,
         dont_delete_files   => $self->dont_delete_files,
+        num_input_files     => $#{$input_files},
       );
       $seg->run();
     }

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -45,7 +45,7 @@ sub _build__memory_required_in_mb {
     my ($self)          = @_;
 
     my $largest_file_size = 1;
-    for my $file (@{$fasta_files})
+    for my $file (@{$self->fasta_files})
     {
         my $file_size = -s $file;
         if($file_size > $largest_file_size)

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -28,23 +28,42 @@ has 'exec'              => ( is => 'ro', isa => 'Str',      default  => 'protein
 has 'translation_table' => ( is => 'rw', isa => 'Int',      default => 11 );
 has 'core_definition'   => ( is => 'ro', isa => 'Num',      default => 1 );
 has 'mafft'             => ( is => 'ro', isa => 'Bool',     default => 0 );
-has 'dont_delete_files' => ( is => 'rw', isa => 'Bool', default  => 0 );
+has 'dont_delete_files' => ( is => 'rw', isa => 'Bool',     default  => 0 );
+has 'num_input_files'   => ( is => 'ro', isa => 'Int',      required => 1);
 
 # Overload Role
 has '_memory_required_in_mb' => ( is => 'ro', isa => 'Int', lazy     => 1, builder => '_build__memory_required_in_mb' );
+has '_min_memory_in_mb'      => ( is => 'ro', isa => 'Int', default => 500 );
+has '_max_memory_in_mb'      => ( is => 'ro', isa => 'Int', default => 60000 );
 has '_queue'                 => ( is => 'rw', isa => 'Str', default  => 'normal' );
-has '_files_per_chunk'       => ( is => 'ro', isa => 'Int', default  => 5 );
+has '_files_per_chunk'       => ( is => 'ro', isa => 'Int', default  => 10 );
 has '_core_alignment_cmd'    => ( is => 'rw', isa => 'Str', lazy_build => 1 );
+
 
 
 sub _build__memory_required_in_mb {
     my ($self)          = @_;
-    my $memory_required = 5000;
+
+    my $largest_file_size = 1;
+    for my $file (@{$fasta_files})
+    {
+        my $file_size = -s $file;
+        if($file_size > $largest_file_size)
+        {
+            $largest_file_size = $file_size;
+        }
+    }
+    
+    my $approx_sequence_length_of_largest_file = $largest_file_size/ $self->num_input_files;
+    my $memory_required = ($approx_sequence_length_of_largest_file*$approx_sequence_length_of_largest_file) + $self->_min_memory_in_mb;
+    
+    $memory_required = $self->_max_memory_in_mb if($memory_required  > $self->_max_memory_in_mb);
+
     return $memory_required;
 }
 
 sub _command_to_run {
-    my ( $self, $fasta_files, ) = @_;
+    my ( $self, $fasta_files) = @_;
 	my $verbose = "";
 	if($self->verbose)
 	{

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -23,13 +23,13 @@ Returns the path to the results file
 use Moose;
 with 'Bio::Roary::JobRunner::Role';
 
-has 'fasta_files'       => ( is => 'ro', isa => 'ArrayRef', required => 1 );
-has 'exec'              => ( is => 'ro', isa => 'Str',      default  => 'protein_alignment_from_nucleotides' );
-has 'translation_table' => ( is => 'rw', isa => 'Int',      default => 11 );
-has 'core_definition'   => ( is => 'ro', isa => 'Num',      default => 1 );
-has 'mafft'             => ( is => 'ro', isa => 'Bool',     default => 0 );
-has 'dont_delete_files' => ( is => 'rw', isa => 'Bool',     default  => 0 );
-has 'num_input_files'   => ( is => 'ro', isa => 'Int',      required => 1);
+has 'fasta_files'                 => ( is => 'ro', isa => 'ArrayRef', required => 1 );
+has 'exec'                        => ( is => 'ro', isa => 'Str',      default  => 'protein_alignment_from_nucleotides' );
+has 'translation_table'           => ( is => 'rw', isa => 'Int',      default => 11 );
+has 'core_definition'             => ( is => 'ro', isa => 'Num',      default => 1 );
+has 'mafft'                       => ( is => 'ro', isa => 'Bool',     default => 0 );
+has 'dont_delete_files'           => ( is => 'rw', isa => 'Bool',     default  => 0 );
+has 'num_input_files'             => ( is => 'ro', isa => 'Int',      required => 1);
 
 # Overload Role
 has '_memory_required_in_mb' => ( is => 'ro', isa => 'Int', lazy     => 1, builder => '_build__memory_required_in_mb' );

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -55,7 +55,7 @@ sub _build__memory_required_in_mb {
     }
     
     my $approx_sequence_length_of_largest_file = $largest_file_size/ $self->num_input_files;
-    my $memory_required = ($approx_sequence_length_of_largest_file*$approx_sequence_length_of_largest_file) + $self->_min_memory_in_mb;
+    my $memory_required = (($approx_sequence_length_of_largest_file*$approx_sequence_length_of_largest_file)/1000000) + $self->_min_memory_in_mb;
     
     $memory_required = $self->_max_memory_in_mb if($memory_required  > $self->_max_memory_in_mb);
 

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -28,11 +28,12 @@ has 'exec'              => ( is => 'ro', isa => 'Str',      default  => 'protein
 has 'translation_table' => ( is => 'rw', isa => 'Int',      default => 11 );
 has 'core_definition'   => ( is => 'ro', isa => 'Num',      default => 1 );
 has 'mafft'             => ( is => 'ro', isa => 'Bool',     default => 0 );
+has 'dont_delete_files' => ( is => 'rw', isa => 'Bool', default  => 0 );
 
 # Overload Role
 has '_memory_required_in_mb' => ( is => 'ro', isa => 'Int', lazy     => 1, builder => '_build__memory_required_in_mb' );
 has '_queue'                 => ( is => 'rw', isa => 'Str', default  => 'normal' );
-has '_files_per_chunk'       => ( is => 'ro', isa => 'Int', default  => 25 );
+has '_files_per_chunk'       => ( is => 'ro', isa => 'Int', default  => 5 );
 has '_core_alignment_cmd'    => ( is => 'rw', isa => 'Str', lazy_build => 1 );
 
 
@@ -59,6 +60,7 @@ sub _build__core_alignment_cmd {
     
     my $core_cmd = "pan_genome_core_alignment";
     $core_cmd .= " -cd " . ($self->core_definition*100) if ( defined $self->core_definition );
+    $core_cmd .= " --dont_delete_files " if ( defined $self->dont_delete_files );
 
     return $core_cmd;
 }

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -55,7 +55,7 @@ sub _build__memory_required_in_mb {
     }
     
     my $approx_sequence_length_of_largest_file = $largest_file_size/ $self->num_input_files;
-    my $memory_required = (($approx_sequence_length_of_largest_file*$approx_sequence_length_of_largest_file)/1000000) + $self->_min_memory_in_mb;
+    my $memory_required = int((($approx_sequence_length_of_largest_file*$approx_sequence_length_of_largest_file)/1000000) + $self->_min_memory_in_mb);
     
     $memory_required = $self->_max_memory_in_mb if($memory_required  > $self->_max_memory_in_mb);
 

--- a/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
+++ b/lib/Bio/Roary/External/GeneAlignmentFromNucleotides.pm
@@ -79,7 +79,7 @@ sub _build__core_alignment_cmd {
     
     my $core_cmd = "pan_genome_core_alignment";
     $core_cmd .= " -cd " . ($self->core_definition*100) if ( defined $self->core_definition );
-    $core_cmd .= " --dont_delete_files " if ( defined $self->dont_delete_files );
+    $core_cmd .= " --dont_delete_files " if ( defined $self->dont_delete_files  && $self->dont_delete_files == 1 );
 
     return $core_cmd;
 }

--- a/lib/Bio/Roary/JobRunner/Parallel.pm
+++ b/lib/Bio/Roary/JobRunner/Parallel.pm
@@ -16,7 +16,6 @@ package Bio::Roary::JobRunner::Parallel;
 =cut
 
 use Moose;
-use File::Slurp::Tiny qw(read_file write_file);
 use File::Temp qw/ tempfile /;
 use Log::Log4perl qw(:easy);
 

--- a/lib/Bio/Roary/MergeMultifastaAlignments.pm
+++ b/lib/Bio/Roary/MergeMultifastaAlignments.pm
@@ -25,6 +25,12 @@ has 'sample_names_to_genes'  => ( is => 'rw', isa => 'HashRef',    required => 1
 has 'output_filename'        => ( is => 'ro', isa => 'Str',        default  => 'core_alignment.aln' );
 has '_output_seqio_obj'      => ( is => 'ro', isa => 'Bio::SeqIO', lazy     => 1, builder => '_build__output_seqio_obj' );
 has '_gene_lengths'          => ( is => 'rw', isa => 'HashRef',    lazy     => 1, builder => '_build__gene_lengths'  );
+has '_gene_to_sequence'      => ( is => 'rw', isa => 'HashRef',    default  => sub {{}});
+
+sub BUILD {
+    my ($self) = @_;
+    $self->_gene_lengths;
+}
 
 sub _input_seq_io_obj {
     my ( $self, $filename ) = @_;
@@ -44,29 +50,29 @@ sub _build__gene_lengths
    {
        my $seq_io = $self->_input_seq_io_obj($filename);
 	   next unless(defined($seq_io ));
-	   my $seq_record = $seq_io->next_seq;
-	   next unless(defined($seq_record ));
-	   $gene_lengths{$filename} = $seq_record->length();
+       while($seq_record = $seq_io->next_seq)
+       {
+           # Save all of the gene sequences to memory, massive speedup but a bit naughty.
+          $self->_gene_to_sequence->{$seq_record->display_id} = $seq_record->seq;
+	      $gene_lengths{$filename} = $seq_record->length() if(!defined($gene_lengths{$filename}));
+       }
    }
+
    return \%gene_lengths;
 }
 
 sub _sequence_for_sample_from_gene_file
 {
 	my ($self, $sample_name, $gene_file) = @_;
-	
-    my $seq_io = $self->_input_seq_io_obj($gene_file);
-    return undef unless(defined($seq_io ));
-	my $seq_record;
-    while($seq_record = $seq_io->next_seq)
-	{
-      if($self->sample_names_to_genes->{$sample_name}->{$seq_record->display_id} )
-	  {
-		  return $seq_record->seq;
-	  }
+
+    if(defined($self->sample_names_to_genes->{$sample_name}->{$gene_file}))
+    {
+      return $self->sample_names_to_genes->{$sample_name}->{$gene_file};
     }
-	
-	return $self->_padded_string_for_gene_file($gene_file);
+    else
+    {
+	  return $self->_padded_string_for_gene_file($gene_file);
+    }
 }
 
 sub _padded_string_for_gene_file

--- a/lib/Bio/Roary/MergeMultifastaAlignments.pm
+++ b/lib/Bio/Roary/MergeMultifastaAlignments.pm
@@ -50,10 +50,10 @@ sub _build__gene_lengths
    {
        my $seq_io = $self->_input_seq_io_obj($filename);
 	   next unless(defined($seq_io ));
-       while($seq_record = $seq_io->next_seq)
+       while(my $seq_record = $seq_io->next_seq)
        {
            # Save all of the gene sequences to memory, massive speedup but a bit naughty.
-          $self->_gene_to_sequence->{$seq_record->display_id} = $seq_record->seq;
+          $self->_gene_to_sequence->{$filename}->{$seq_record->display_id} = $seq_record->seq;
 	      $gene_lengths{$filename} = $seq_record->length() if(!defined($gene_lengths{$filename}));
        }
    }
@@ -64,15 +64,16 @@ sub _build__gene_lengths
 sub _sequence_for_sample_from_gene_file
 {
 	my ($self, $sample_name, $gene_file) = @_;
-
-    if(defined($self->sample_names_to_genes->{$sample_name}->{$gene_file}))
+    
+    # loop over this to get the geneIDs
+    for my $gene_id (keys %{$self->_gene_to_sequence->{$gene_file}})
     {
-      return $self->sample_names_to_genes->{$sample_name}->{$gene_file};
+        if(defined($self->sample_names_to_genes->{$sample_name}->{$gene_id}))
+        {
+          return $self->_gene_to_sequence->{$gene_file}->{$gene_id};
+        }
     }
-    else
-    {
 	  return $self->_padded_string_for_gene_file($gene_file);
-    }
 }
 
 sub _padded_string_for_gene_file

--- a/lib/Bio/Roary/SplitGroups.pm
+++ b/lib/Bio/Roary/SplitGroups.pm
@@ -14,7 +14,7 @@ use File::Path qw(make_path remove_tree);
 use File::Copy qw(move);
 use File::Temp;
 use File::Basename;
-use File::Slurp::Tiny 'read_lines';
+use File::Slurper 'read_lines';
 use Cwd;
 
 
@@ -86,7 +86,7 @@ sub _build__genes_to_neighbourhood
 	my ( $filename, $directories, $suffix ) = fileparse( $fasta_file, qr/\.[^.]*/ );
   	system('grep \> '.$fasta_file.'| sed  \'s/>//\' >'.$self->_gene_files_temp_dir_obj."/".$filename.$suffix ) ;
 	
-	my @genes = read_lines($self->_gene_files_temp_dir_obj."/".$filename.$suffix, chomp => 1 );
+	my @genes = read_lines($self->_gene_files_temp_dir_obj."/".$filename.$suffix );
 	
 	for(my $i =0; $i< @genes; $i++)
 	{

--- a/t/Bio/Roary/AccessoryBinaryFasta.t
+++ b/t/Bio/Roary/AccessoryBinaryFasta.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/AnalyseGroups.t
+++ b/t/Bio/Roary/AnalyseGroups.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/AnnotateGroups.t
+++ b/t/Bio/Roary/AnnotateGroups.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Moose;
 BEGIN { unshift( @INC, './t/lib' ) }
 with 'TestHelper';

--- a/t/Bio/Roary/AssemblyStatistics.t
+++ b/t/Bio/Roary/AssemblyStatistics.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/ChunkFastaFile.t
+++ b/t/Bio/Roary/ChunkFastaFile.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -19,7 +19,7 @@ ok($obj = Bio::Roary::ChunkFastaFile->new(
   fasta_file   => 't/data/example_1.faa',
 ),'initalise object to produce a single sequence file');
 is_deeply($obj->sequence_file_names, [$obj->_working_directory_name.'/0.seq'], 'a single sequence file is created' );
-is(read_file('t/data/example_1.faa'), read_file($obj->_working_directory_name.'/0.seq'), 'input and output file should be the same');
+compare_ok('t/data/example_1.faa', $obj->_working_directory_name.'/0.seq', 'input and output file should be the same');
 
 ok($obj = Bio::Roary::ChunkFastaFile->new(
   fasta_file        => 't/data/example_1.faa',
@@ -34,8 +34,8 @@ $obj->_working_directory_name.'/4.seq',
 $obj->_working_directory_name.'/5.seq',
 ], 
 'a sequence file per sequence is created' );
-is(read_file('t/data/expected_0.seq'), read_file($obj->_working_directory_name.'/0.seq'), 'the first sequence file is as expected');
-is(read_file('t/data/expected_5.seq'), read_file($obj->_working_directory_name.'/5.seq'), 'the last sequence file is as expected');
+compare_ok('t/data/expected_0.seq',$obj->_working_directory_name.'/0.seq', 'the first sequence file is as expected');
+compare_ok('t/data/expected_5.seq', $obj->_working_directory_name.'/5.seq', 'the last sequence file is as expected');
 
 
 done_testing();

--- a/t/Bio/Roary/CombinedProteome.t
+++ b/t/Bio/Roary/CombinedProteome.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -24,19 +24,16 @@ ok(
 
 ok( $obj->create_combined_proteome_file, 'Create a combined file' );
 
-is(
-    read_file('combined_proteome.fa'),
-    read_file('t/data/expected_combined_proteome.fa'),
+compare_ok('combined_proteome.fa',
+    't/data/expected_combined_proteome.fa',
     'Combined file is as expected'
 );
 unlink('combined_proteome.fa');
-
 
 throws_ok{
     Bio::Roary::CombinedProteome->new(
         proteome_files  => [ 't/data/example_1.faa', 't/data/non_existant_file.faa' ],
         output_filename => 'combined_proteome.fa')
     } qr /Cant open file/, 'non existant files should throw an error';
-
 
 done_testing();

--- a/t/Bio/Roary/CommandLine/ExtractProteomeFromGff.t
+++ b/t/Bio/Roary/CommandLine/ExtractProteomeFromGff.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/CommandLine/GeneAlignmentFromNucleotides.t
+++ b/t/Bio/Roary/CommandLine/GeneAlignmentFromNucleotides.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 use File::Which;
 

--- a/t/Bio/Roary/CommandLine/ParallelAllAgainstAllBlastp.t
+++ b/t/Bio/Roary/CommandLine/ParallelAllAgainstAllBlastp.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/CommandLine/QueryRoary.t
+++ b/t/Bio/Roary/CommandLine/QueryRoary.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/CommandLine/Roary.t
+++ b/t/Bio/Roary/CommandLine/Roary.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use File::Path qw( remove_tree);
 use File::Which;
 use File::Path qw(make_path);

--- a/t/Bio/Roary/CommandLine/RoaryCoreAlignment.t
+++ b/t/Bio/Roary/CommandLine/RoaryCoreAlignment.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/CommandLine/RoaryPostAnalysis.t
+++ b/t/Bio/Roary/CommandLine/RoaryPostAnalysis.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use File::Path qw( remove_tree);
 use Cwd;
 

--- a/t/Bio/Roary/CommandLine/RoaryReorderSpreadsheet.t
+++ b/t/Bio/Roary/CommandLine/RoaryReorderSpreadsheet.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/CommandLine/TransferAnnotationToGroups.t
+++ b/t/Bio/Roary/CommandLine/TransferAnnotationToGroups.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
 use Moose;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/ContigsToGeneIDsFromGFF.t
+++ b/t/Bio/Roary/ContigsToGeneIDsFromGFF.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/External/Mafft.t
+++ b/t/Bio/Roary/External/Mafft.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 use Cwd;
-use File::Slurp::Tiny qw(read_file write_file);
 use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/External/Mcl.t
+++ b/t/Bio/Roary/External/Mcl.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Data::Dumper;
 use Cwd;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 
@@ -45,7 +45,7 @@ ok(
     'initialise object with real values'
 );
 ok( $obj->run(), 'run the real command' );
-is(read_file('output_groups'), read_file('t/data/expected_output_groups'), 'outgroups as expected');
+compare_ok('output_groups', 't/data/expected_output_groups', 'outgroups as expected');
 
 unlink('output_groups');
 

--- a/t/Bio/Roary/External/Prank.t
+++ b/t/Bio/Roary/External/Prank.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 use Cwd;
-use File::Slurp::Tiny qw(read_file write_file);
 use Test::Files;
 use Bio::Roary::SortFasta;
 

--- a/t/Bio/Roary/ExtractCoreGenesFromSpreadsheet.t
+++ b/t/Bio/Roary/ExtractCoreGenesFromSpreadsheet.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/ExtractProteomeFromGFFs.t
+++ b/t/Bio/Roary/ExtractProteomeFromGFFs.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Data::Dumper;
 use File::Basename;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -27,9 +27,8 @@ my @sorted_expected_files = sort( ( 'example_annotation.gff.proteome.faa', 'exam
 
 is_deeply( \@sorted_fasta_files, \@sorted_expected_files, 'one file created' );
 
-is(
-    read_file( $plot_groups_obj->fasta_files->[0] ),
-    read_file('t/data/example_annotation.gff.proteome.faa.expected'),
+compare_ok( $plot_groups_obj->fasta_files->[0] ,
+    't/data/example_annotation.gff.proteome.faa.expected',
     'content of proteome 1 as expected'
 );
 
@@ -49,9 +48,8 @@ is_deeply( \@sorted_fasta_files, \@sorted_expected_files, 'GB files created outp
 
 for my $full_filename ( @{ $plot_groups_obj->fasta_files() } ) {
     my $base_filename = basename($full_filename);
-    is(
-        read_file($full_filename),
-        read_file( 't/data/genbank_gbff/' . $base_filename . '.expected' ),
+    compare_ok($full_filename,
+        't/data/genbank_gbff/' . $base_filename . '.expected',
         "content of proteome $full_filename as expected"
     );
 }
@@ -73,7 +71,7 @@ is_deeply( \@sorted_fasta_files, \@sorted_expected_files, 'locus tag id files cr
 
 for my $full_filename ( @{ $plot_groups_obj->fasta_files() } ) {
     my $base_filename = basename($full_filename);
-    is( read_file($full_filename), read_file( 't/data/locus_tag_gffs/' . $base_filename . '.expected' ),
+    compare_ok($full_filename, 't/data/locus_tag_gffs/' . $base_filename . '.expected' ,
         "content of proteome $full_filename as expected" );
 }
 

--- a/t/Bio/Roary/FilterFullClusters.t
+++ b/t/Bio/Roary/FilterFullClusters.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -25,11 +25,9 @@ ok(my $filter_clusters = Bio::Roary::FilterFullClusters->new(
 ok($filter_clusters->filter_full_clusters_from_fasta(),'filter the clusters');
 ok($filter_clusters->filter_complete_cluster_from_original_fasta(),'filter original input and save full groups');
 
-
-is(read_file('output_filtered.fa'), read_file('t/data/expected_output_filtered.fa'), 'content as expected');
-
-is(read_file('output_groups'), read_file('t/data/expected_output_groups_cdhit'), 'content as expected');
-is(read_file('filtered_original_input.fa'), read_file('t/data/expected_filtered_original_input.fa'), 'content as expected');
+compare_ok('output_filtered.fa', 't/data/expected_output_filtered.fa', 'content as expected');
+compare_ok('output_groups', 't/data/expected_output_groups_cdhit', 'content as expected');
+compare_ok('filtered_original_input.fa', 't/data/expected_filtered_original_input.fa', 'content as expected');
 
 unlink('output_groups');
 unlink('filtered_original_input.fa');

--- a/t/Bio/Roary/GeneNamesFromGFF.t
+++ b/t/Bio/Roary/GeneNamesFromGFF.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/GroupLabels.t
+++ b/t/Bio/Roary/GroupLabels.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -19,7 +19,7 @@ ok(
     'initialise with a groups file'
 );
 ok($obj->add_labels, 'Add labels to groups');
-is(read_file($obj->output_filename), read_file('t/data/expected_group_labels'), 'groups labeled as expected');
+compare_ok($obj->output_filename, 't/data/expected_group_labels', 'groups labeled as expected');
 unlink('labelled_groups_file');
 
 done_testing();

--- a/t/Bio/Roary/GroupStatistics.t
+++ b/t/Bio/Roary/GroupStatistics.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -30,7 +30,7 @@ ok($obj = Bio::Roary::GroupStatistics->new(
 ),'Initialise group statistics object');
 ok($obj->create_spreadsheet,'Create the CSV file');
 ok(-e 'group_statitics.csv', 'CSV file exists');
-is(read_file('group_statitics.csv'),read_file('t/data/expected_group_statitics.csv'), 'Spreadsheet content as expected');
+compare_ok('group_statitics.csv','t/data/expected_group_statitics.csv', 'Spreadsheet content as expected');
 
 unlink('group_statitics.csv');
 
@@ -54,7 +54,7 @@ ok($obj = Bio::Roary::GroupStatistics->new(
 ),'Initialise group statistics object where one isolate has only 1 gene');
 ok($obj->create_spreadsheet,'Create the CSV file');
 ok(-e 'missing_genes_stats.csv', 'CSV file exists');
-is(read_file('missing_genes_stats.csv'),read_file('t/data/expected_group_statitics_missing_genes.csv'), 'Spreadsheet content as expected with missing genes');
+compare_ok('missing_genes_stats.csv','t/data/expected_group_statitics_missing_genes.csv', 'Spreadsheet content as expected with missing genes');
 
 unlink('missing_genes_stats.csv');
 
@@ -69,7 +69,7 @@ ok($obj = Bio::Roary::GroupStatistics->new(
 ),'Initialise group statistics object');
 ok($obj->create_spreadsheet,'Create the CSV file');
 ok(-e 'verbose_stats.csv', 'CSV file exists');
-is(read_file('verbose_stats.csv'),read_file('t/data/expected_group_statitics_verbose.csv'), 'Verbose spreadsheet content as expected');
+compare_ok('verbose_stats.csv','t/data/expected_group_statitics_verbose.csv', 'Verbose spreadsheet content as expected');
 
 unlink('verbose_stats.csv');
 

--- a/t/Bio/Roary/InflateClusters.t
+++ b/t/Bio/Roary/InflateClusters.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -22,7 +22,7 @@ ok( $obj = Bio::Roary::InflateClusters->new(
 ),'initialise object');
 ok($obj->inflate,'inflate the results');
 
-is(read_file('example.output'),read_file('t/data/expected_inflated_results'), 'inflated results as expected');
+compare_ok('example.output','t/data/expected_inflated_results', 'inflated results as expected');
 unlink('example.output');
 
 
@@ -33,7 +33,7 @@ ok( $obj = Bio::Roary::InflateClusters->new(
 ),'initialise object');
 ok($obj->inflate,'inflate the results');
 
-is(read_file('example.output'),read_file('t/data/expected_clusters_to_inflate'), 'inflated results as expected');
+compare_ok('example.output','t/data/expected_clusters_to_inflate', 'inflated results as expected');
 unlink('example.output');
 
 done_testing();

--- a/t/Bio/Roary/OrderGenes.t
+++ b/t/Bio/Roary/OrderGenes.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use File::Slurper 'read_text';
 use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
@@ -54,9 +54,9 @@ ok( $obj->groups_to_contigs,       'build the graph for sample weights' );
 ok( -e 'core_accessory_graph.dot', 'core accessory graph created for sample weights' );
 ok( -e 'accessory_graph.dot',      'accessory graph created for sample weights' );
 
-my $actual_graph = read_file('accessory_graph.dot');
+my $actual_graph = read_text('accessory_graph.dot');
 $actual_graph =~ s/group_[\w]/group_X/gi;
-is_deeply( $actual_graph, read_file('t/data/expected_sample_weights_accessory_graph.dot'), 'graph weights changed' );
+is_deeply( $actual_graph, read_text('t/data/expected_sample_weights_accessory_graph.dot'), 'graph weights changed' );
 
 # Check how the final graphs get reordered.
 

--- a/t/Bio/Roary/Output/GroupsMultifastaProtein.t
+++ b/t/Bio/Roary/Output/GroupsMultifastaProtein.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 
@@ -19,7 +19,7 @@ ok(
 );
 ok($obj->convert_nucleotide_to_protein(),'perform the conversion');
 
-is(read_file('t/data/nuc_multifasta.faa'),read_file('t/data/expected_nuc_multifasta.faa' ),'File content as expected');
+compare_ok('t/data/nuc_multifasta.faa', 't/data/expected_nuc_multifasta.faa', 'File content as expected');
 
 unlink('t/data/nuc_multifasta.faa');
 

--- a/t/Bio/Roary/Output/GroupsMultifastas.t
+++ b/t/Bio/Roary/Output/GroupsMultifastas.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 
@@ -30,14 +30,12 @@ ok( $obj->create_files(), 'Create multiple fasta files' );
 ok( -e $obj->output_filename_base . '_group_2.fa', $obj->output_filename_base . '_group_2.fa'.' group created' );
 ok( -e $obj->output_filename_base . '_group_5.fa', $obj->output_filename_base . '_group_2.fa'.' group created' );
 
-is(
-    read_file( $obj->output_filename_base . '_group_2.fa' ),
-    read_file('t/data/expected_output_groups_group_2_multi.fa'),
+compare_ok( $obj->output_filename_base . '_group_2.fa' ,
+    't/data/expected_output_groups_group_2_multi.fa',
     'group 2 contect as expected'
 );
-is(
-    read_file( $obj->output_filename_base . '_group_5.fa' ),
-    read_file('t/data/expected_output_groups_group_5_multi.fa'),
+compare_ok( $obj->output_filename_base . '_group_5.fa' ,
+    't/data/expected_output_groups_group_5_multi.fa',
     'group 5 contect as expected'
 );
 

--- a/t/Bio/Roary/Output/GroupsMultifastasNucleotide.t
+++ b/t/Bio/Roary/Output/GroupsMultifastasNucleotide.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use File::Path qw( remove_tree);
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
@@ -60,7 +59,7 @@ ok(
 );
 ok( $obj->create_files(), 'Create multiple fasta files where you delete non core files' );
 
-is(read_file('pan_genome_sequences/hly.fa'),     read_file('t/data/pan_genome_sequences/hly.fa' ), 'Check multifasta content is correct for 3-hly.fa ');
+compare_ok('pan_genome_sequences/hly.fa', 't/data/pan_genome_sequences/hly.fa' , 'Check multifasta content is correct for 3-hly.fa ');
 ok(! -e 'pan_genome_sequences/speH.fa', 'Check 2-speH.fa doesnt exist since its non core');
 ok(! -e 'pan_genome_sequences/argF.fa', 'Check 2-argF.fa doesnt exist since its non core');
 cleanup_files();

--- a/t/Bio/Roary/Output/NumberOfGroups.t
+++ b/t/Bio/Roary/Output/NumberOfGroups.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
-
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 
@@ -38,19 +37,19 @@ ok(my $obj = Bio::Roary::Output::NumberOfGroups->new(
 ok($obj->create_output_files, 'create the raw output file');
 
 ok(-e 'number_of_conserved_genes.Rtab', 'check raw output file created');
-is(read_file('t/data/expected_number_of_conserved_genes.tab'), read_file('number_of_conserved_genes.Rtab'), 'Content of total groups tab file as expected');
+compare_ok('t/data/expected_number_of_conserved_genes.tab', 'number_of_conserved_genes.Rtab', 'Content of total groups tab file as expected');
 unlink('number_of_conserved_genes.Rtab');
 
 ok(-e 'number_of_new_genes.Rtab', 'check raw output file created');
-is(read_file('t/data/expected_number_of_new_genes.tab'), read_file('number_of_new_genes.Rtab'), '');
+compare_ok('t/data/expected_number_of_new_genes.tab', 'number_of_new_genes.Rtab', '');
 unlink('number_of_new_genes.Rtab');
 
 ok(-e 'number_of_genes_in_pan_genome.Rtab', 'check raw output file created');
-is(read_file('t/data/expected_number_of_genes_in_pan_genome.tab'), read_file('number_of_genes_in_pan_genome.Rtab'), 'Content of total groups tab file as expected');
+compare_ok('t/data/expected_number_of_genes_in_pan_genome.tab', 'number_of_genes_in_pan_genome.Rtab', 'Content of total groups tab file as expected');
 unlink('number_of_genes_in_pan_genome.Rtab');
 
 ok(-e 'number_of_unique_genes.Rtab', 'check raw output file created');
-is(read_file('t/data/expected_number_of_unique_genes.tab'), read_file('number_of_unique_genes.Rtab'), 'Content of unique groups tab file as expected');
+compare_ok('t/data/expected_number_of_unique_genes.tab', 'number_of_unique_genes.Rtab', 'Content of unique groups tab file as expected');
 unlink('number_of_unique_genes.Rtab');
 
 
@@ -61,7 +60,7 @@ ok($obj = Bio::Roary::Output::NumberOfGroups->new(
   core_definition => 0.6
   ),"initialise object with 60 percent core definition");
 ok($obj->create_output_files, 'create the raw output files for 60 percent core def');
-is(read_file('t/data/expected_number_of_conserved_genes_0.6.tab'), read_file('number_of_conserved_genes.Rtab'), 'Content of conserved genes with 60 percent core def');
+compare_ok('t/data/expected_number_of_conserved_genes_0.6.tab','number_of_conserved_genes.Rtab', 'Content of conserved genes with 60 percent core def');
 
 unlink('number_of_conserved_genes.Rtab');
 unlink('number_of_new_genes.Rtab');

--- a/t/Bio/Roary/Output/QueryGroups.t
+++ b/t/Bio/Roary/Output/QueryGroups.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file read_lines);
 use Moose;
 BEGIN { unshift( @INC, './t/lib' ) }
 with 'TestHelper';

--- a/t/Bio/Roary/ParallelAllAgainstAllBlast.t
+++ b/t/Bio/Roary/ParallelAllAgainstAllBlast.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 use Cwd;
 
 BEGIN { unshift( @INC, './lib' ) }

--- a/t/Bio/Roary/PrepareInputFiles.t
+++ b/t/Bio/Roary/PrepareInputFiles.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 use File::Basename;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/QC/Report.t
+++ b/t/Bio/Roary/QC/Report.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 use File::Which;
 
 BEGIN { unshift( @INC, './lib' ) }
@@ -34,7 +34,7 @@ ok(
 ok( $qc_report_obj->report, 'report generated' );
 ok( -e 'kraken_report.csv', 'report file exists' );
 
-is( read_file('kraken_report.csv'), read_file("t/data/exp_qc_report.csv"), 'report file correct' );
+compare_ok('kraken_report.csv',"t/data/exp_qc_report.csv", 'report file correct' );
 
 unlink('kraken_report.csv');
 
@@ -62,14 +62,12 @@ ok( my $nuc_files = $qc_report_obj->_extract_nuc_files_from_all_gffs(), 'extract
 is_deeply( [ $qc_report_obj->_tmp_directory . '/query_1.fna', $qc_report_obj->_tmp_directory . '/query_2.fna' ],
     $nuc_files, 'check extracted nuc files from gffs list' );
 
-is(
-    read_file( $qc_report_obj->_tmp_directory . '/query_1.fna' ),
-    read_file('t/data/expected_query_1.fna'),
+compare_ok( $qc_report_obj->_tmp_directory . '/query_1.fna' ,
+    't/data/expected_query_1.fna',
     'Check FASTA file 1 extracted as expected'
 );
-is(
-    read_file( $qc_report_obj->_tmp_directory . '/query_2.fna' ),
-    read_file('t/data/expected_query_2.fna'),
+compare_ok( $qc_report_obj->_tmp_directory . '/query_2.fna' ,
+    't/data/expected_query_2.fna',
     'Check FASTA file 2 extracted as expected'
 );
 
@@ -92,7 +90,7 @@ SKIP:
     
     ok( $qc_report_obj->report, 'report generated with real data' );
     ok( -e 'kraken_report.csv', 'report file exists with real data' );
-    is( read_file('kraken_report.csv'), read_file("t/data/exp_qc_report_real.csv"), 'report file correct' );
+    compare_ok('kraken_report.csv',"t/data/exp_qc_report_real.csv", 'report file correct' );
     unlink('kraken_report.csv');
     
 }

--- a/t/Bio/Roary/ReformatInputGFFs.t
+++ b/t/Bio/Roary/ReformatInputGFFs.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Data::Dumper;
 use File::Path qw(remove_tree);
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -42,7 +42,7 @@ ok($obj->fix_duplicate_gene_ids, 'fix duplicates with 2 input gffs');
 ok(( -d 'fixed_input_files'), 'Directory should exist because there is one gff thats fixed');
 is_deeply($obj->fixed_gff_files, ['t/data/reformat_input_gffs/query_1.gff','fixed_input_files/query_2.gff' ] ,'list of gff files one in the fixed directory');
 ok(( -e 'fixed_input_files/query_2.gff'), 'fixed file should exist');
-is_deeply(read_file('fixed_input_files/query_2.gff'),  read_file('t/data/reformat_input_gffs/expected_fixed_query_2.gff'),  'fixed file should have expected changes');
+compare_ok('fixed_input_files/query_2.gff', 't/data/reformat_input_gffs/expected_fixed_query_2.gff',  'fixed file should have expected changes');
 remove_tree('fixed_input_files');
 
 
@@ -53,15 +53,15 @@ ok(( -d 'fixed_input_files'), 'Directory should exist because there is 2 gffs th
 is_deeply($obj->fixed_gff_files, ['t/data/reformat_input_gffs/query_1.gff','fixed_input_files/query_2.gff','fixed_input_files/query_3.gff' ] ,'list of gff files 2 in the fixed directory');
 ok(( -e 'fixed_input_files/query_2.gff'), 'fixed file should exist');
 ok(( -e 'fixed_input_files/query_3.gff'), 'fixed file should exist');
-is_deeply(read_file('fixed_input_files/query_2.gff'),  read_file('t/data/reformat_input_gffs/expected_fixed_query_2.gff'),  'fixed file should have expected changes');
-is_deeply(read_file('fixed_input_files/query_3.gff'),  read_file('t/data/reformat_input_gffs/expected_fixed_query_3.gff'),  'fixed file should have expected changes');
+compare_ok('fixed_input_files/query_2.gff','t/data/reformat_input_gffs/expected_fixed_query_2.gff',  'fixed file should have expected changes');
+compare_ok('fixed_input_files/query_3.gff', 't/data/reformat_input_gffs/expected_fixed_query_3.gff',  'fixed file should have expected changes');
 remove_tree('fixed_input_files');
 	
 
 ok($obj = Bio::Roary::ReformatInputGFFs->new(gff_files => ['t/data/reformat_input_gffs/real_1.gff']), 'initialise with 1 gff that has shown to have a bug');
 ok(my $fixed_file = $obj->_add_suffix_to_gene_ids_and_return_new_file('t/data/reformat_input_gffs/real_1.gff'), 'fix duplicates');
 ok(( -e 'fixed_input_files/real_1.gff'), 'fixed file should exist');
-is_deeply(read_file('fixed_input_files/real_1.gff'),  read_file('t/data/reformat_input_gffs/expected_real_1.gff'),  'fixed file should have expected changes');
+compare_ok('fixed_input_files/real_1.gff', 't/data/reformat_input_gffs/expected_real_1.gff',  'fixed file should have expected changes');
 remove_tree('fixed_input_files');
 
 

--- a/t/Bio/Roary/ReorderSpreadsheet.t
+++ b/t/Bio/Roary/ReorderSpreadsheet.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -21,18 +21,13 @@ ok(
     ),
     'initialise reordering the spreadsheet'
 );
-
-
-
         
 is_deeply($obj->_column_mappings,[0,1,2,3,4,5,6,7,8,9,10,11,12,13],'Column mappings with fixed in same order and end columns ordered by tree file');
 ok( $obj->reorder_spreadsheet(), 'run the reorder method' );
 ok( -e $obj->output_filename,    'check the output file exists' );
 
-
-is(
-    read_file('t/data/reorder_isolates_expected_output.csv'),
-    read_file('reorder_isolates_output.csv'),
+compare_ok('t/data/reorder_isolates_expected_output.csv',
+    'reorder_isolates_output.csv',
     'content of the spreadsheet as expected'
 );
 

--- a/t/Bio/Roary/SampleOrder.t
+++ b/t/Bio/Roary/SampleOrder.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/SequenceLengths.t
+++ b/t/Bio/Roary/SequenceLengths.t
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";

--- a/t/Bio/Roary/SplitGroups.t
+++ b/t/Bio/Roary/SplitGroups.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file);
+use Test::Files;
 
 BEGIN { unshift( @INC, './lib' ) }
 $ENV{PATH} .= ":./bin";
@@ -24,7 +24,7 @@ ok( $obj = Bio::Roary::SplitGroups->new(
 
 $obj->split_groups;
 ok( -e 'blah.out', 'output file exists' );
-is(read_file('blah.out'), read_file('t/data/split_groups/paralog_exp_clusters1'), 'split group output correct for test 1');
+compare_ok('blah.out','t/data/split_groups/paralog_exp_clusters1', 'split group output correct for test 1');
 
 # test 2 - partial sharing of CGN
 ok( $obj = Bio::Roary::SplitGroups->new(
@@ -36,7 +36,7 @@ ok( $obj = Bio::Roary::SplitGroups->new(
 
 $obj->split_groups;
 ok( -e 'blah2.out', 'output file exists' );
-is(read_file('blah2.out'), read_file('t/data/split_groups/paralog_exp_clusters2'), 'split group output correct for test 2');
+compare_ok('blah2.out', 't/data/split_groups/paralog_exp_clusters2', 'split group output correct for test 2');
 
 # test 3 - one gene with no shared CGN
 ok( $obj = Bio::Roary::SplitGroups->new(
@@ -48,7 +48,7 @@ ok( $obj = Bio::Roary::SplitGroups->new(
 
 $obj->split_groups;
 ok( -e 'blah3.out', 'output file exists' );
-is(read_file('blah3.out'), read_file('t/data/split_groups/paralog_exp_clusters3'), 'split group output correct for test 3');
+compare_ok('blah3.out', 't/data/split_groups/paralog_exp_clusters3', 'split group output correct for test 3');
 
 # test 4 - paralogs inside paralogs (inception paralog)
 ok( $obj = Bio::Roary::SplitGroups->new(
@@ -60,7 +60,7 @@ ok( $obj = Bio::Roary::SplitGroups->new(
 
 $obj->split_groups;
 ok( -e 'blah4.out', 'output file exists' );
-is(read_file('blah4.out'), read_file('t/data/split_groups/paralog_exp_clusters4'), 'split group output correct for test 4');
+compare_ok('blah4.out','t/data/split_groups/paralog_exp_clusters4', 'split group output correct for test 4');
 
 unlink( "blah.out" );
 unlink( "blah2.out" );

--- a/t/lib/TestHelper.pm
+++ b/t/lib/TestHelper.pm
@@ -2,7 +2,7 @@ package TestHelper;
 use Moose::Role;
 use Test::Most;
 use Data::Dumper;
-use File::Slurp::Tiny qw(read_file write_file read_lines);
+use File::Slurper qw(read_lines read_text);
 use Test::Files;
 use Test::Output;
 
@@ -288,7 +288,7 @@ sub compare_tab_files_with_variable_coordinates {
 
 sub _filter_coordinates_from_string {
     my ($file_name) = @_;
-    my $file_contents = read_file($file_name);
+    my $file_contents = read_text($file_name);
     my @lines = split( /\n/, $file_contents );
     my $modified_file_contents = '';
     for my $line ( sort @lines ) {
@@ -301,7 +301,7 @@ sub _filter_coordinates_from_string {
 
 sub _exclude_variable_columns_from_spreadsheet {
     my ( $file_name, $columns_to_exclude ) = @_;
-    my $file_contents          = read_file($file_name);
+    my $file_contents          = read_text($file_name);
     my @lines                  = split( /\n/, $file_contents );
     my $modified_file_contents = '';
 


### PR DESCRIPTION
If LSF is available, submit the the individual gene alignments as jobs to speed things up.
https://github.com/sanger-pathogens/LSF_jobrunner_Roary
Speedup merging core genes into a single FASTA by reading into memory.
Remove the use of File::Slurp
Tidy readme