### PR TITLE
add optional dependancy from File::Slurper to stop warnings being printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export PERL5LIB=$PERL5LIB:$HOME/Roary-x.x.x/lib
 Install the perl dependancies:
 
 ```
-sudo cpanm  Array::Utils Bio::Perl Exception::Class File::Basename File::Copy File::Find::Rule File::Grep File::Path File::Slurper File::Spec File::Temp File::Which FindBin Getopt::Long Graph Graph::Writer::Dot List::Util Log::Log4perl Moose Moose::Role Text::CSV
+sudo cpanm  Array::Utils Bio::Perl Exception::Class File::Basename File::Copy File::Find::Rule File::Grep File::Path File::Slurper File::Spec File::Temp File::Which FindBin Getopt::Long Graph Graph::Writer::Dot List::Util Log::Log4perl Moose Moose::Role Text::CSV PerlIO::utf8_strict 
 ```
 Install the external dependances either from source or from your packaging system:
 ```

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.4.3
+version = 3.5.0
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute
@@ -19,6 +19,8 @@ repository.type = git
 [PodWeaver]
 [PkgVersion]
 
+[Prereqs]
+PerlIO::utf8_strict   = 0
 
 [Encoding]
 filename = t/data/kraken_test/database.idx


### PR DESCRIPTION
Fixes issues raised in:
https://github.com/sanger-pathogens/Roary/issues/196
RT499877
RT496629


