### PR TITLE
Accessory binary fasta contains all C's fix

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.5.2
+version = 3.5.3
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/AccessoryBinaryFasta.pm
+++ b/lib/Bio/Roary/AccessoryBinaryFasta.pm
@@ -78,7 +78,7 @@ sub create_accessory_binary_fasta {
 
             next if ( @files <= $self->_lower_bound_value || @files > $self->_upper_bound_value );
 
-            my $group_to_file_genes = $self->groups_to_files->{$group}->{$filename};
+            my $group_to_file_genes = $self->groups_to_files->{$group}->{$full_filename};
             if ( defined($group_to_file_genes) && @{$group_to_file_genes} > 0 ) {
                 $output_sequence .= 'A';
             }

--- a/t/Bio/Roary/AccessoryBinaryFasta.t
+++ b/t/Bio/Roary/AccessoryBinaryFasta.t
@@ -28,10 +28,10 @@ ok(
         input_files => [ 't/abc/aaa', 't/abc/bbb', 't/abc/ccc', 't/abc/ddd' ],
         groups_to_files => 
 		{
-            group_1 => { 'aaa' => [1] },
-            group_2 => { 'aaa' => [1], 'bbb' => [2] },
-            group_3 => { 'aaa' => [1], 'bbb' => [2], 'ccc' => [3] },
-            group_4 => { 'aaa' => [1], 'bbb' => [2], 'ccc' => [3], 'ddd' => [4] },
+            group_1 => { 't/abc/aaa' => [1] },
+            group_2 => { 't/abc/aaa' => [1], 't/abc/bbb' => [2] },
+            group_3 => { 't/abc/aaa' => [1], 't/abc/bbb' => [2], 't/abc/ccc' => [3] },
+            group_4 => { 't/abc/aaa' => [1], 't/abc/bbb' => [2], 't/abc/ccc' => [3], 't/abc/ddd' => [4] },
         },
 		_lower_bound_value  => 0,
 		_upper_bound_value  => 4,

--- a/t/Bio/Roary/CommandLine/Roary.t
+++ b/t/Bio/Roary/CommandLine/Roary.t
@@ -31,16 +31,16 @@ cleanup_files();
 
 %scripts_and_expected_files = (
 
-#   ' --dont_split_groups   t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
-#     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
-#   ' -j Local -t 1 --dont_split_groups   t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
-#     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
-#   ' -j Parallel  --dont_split_groups t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
-#     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
-#   ' -t 1 -j Parallel --dont_split_groups  t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
-#     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
-#   ' -j Local --dont_split_groups t/data/genbank_gbff/genbank1.gff t/data/genbank_gbff/genbank2.gff t/data/genbank_gbff/genbank3.gff' =>
-#     [ 'gene_presence_absence.csv', 't/data/genbank_gbff/genbank_gene_presence_absence.csv' ],
+   ' --dont_split_groups  ca   ' =>
+     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
+   ' -j Local -t 1 --dont_split_groups   t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
+     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
+   ' -j Parallel  --dont_split_groups t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
+     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
+   ' -t 1 -j Parallel --dont_split_groups  t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
+     [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
+   ' -j Local --dont_split_groups t/data/genbank_gbff/genbank1.gff t/data/genbank_gbff/genbank2.gff t/data/genbank_gbff/genbank3.gff' =>
+     [ 'gene_presence_absence.csv', 't/data/genbank_gbff/genbank_gene_presence_absence.csv' ],
     '-h' => [ 'empty_file', 't/data/empty_file' ],
 );
 

--- a/t/Bio/Roary/CommandLine/Roary.t
+++ b/t/Bio/Roary/CommandLine/Roary.t
@@ -31,7 +31,7 @@ cleanup_files();
 
 %scripts_and_expected_files = (
 
-   ' --dont_split_groups  ca   ' =>
+   ' --dont_split_groups   t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
      [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],
    ' -j Local -t 1 --dont_split_groups   t/data/query_1.gff t/data/query_2.gff t/data/query_5.gff    ' =>
      [ 'gene_presence_absence.csv', 't/data/overall_gene_presence_absence.csv' ],


### PR DESCRIPTION
Fixes issue:
https://github.com/sanger-pathogens/Roary/issues/202

where the accessory fasta file is full of C's and the tree has no branch lengths