### PR TITLE
CD-hit threads limit

### DIFF
--- a/bin/create_pan_genome_plots.R
+++ b/bin/create_pan_genome_plots.R
@@ -7,19 +7,19 @@ library(ggplot2)
 
 mydata = read.table("number_of_new_genes.Rtab")
 boxplot(mydata, data=mydata, main="Number of new genes",
-         xlab="Number of genomes", ylab="Number of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
+         xlab="No. of genomes", ylab="No. of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
 
 mydata = read.table("number_of_conserved_genes.Rtab")
 boxplot(mydata, data=mydata, main="Number of conserved genes",
-          xlab="Number of genomes", ylab="Number of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
+          xlab="No. of genomes", ylab="No. of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
  
 mydata = read.table("number_of_genes_in_pan_genome.Rtab")
-boxplot(mydata, data=mydata, main="Number of genes in the pan-genome",
-          xlab="Number of genomes", ylab="Number of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
+boxplot(mydata, data=mydata, main="No. of genes in the pan-genome",
+          xlab="No. of genomes", ylab="No. of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
 
 mydata = read.table("number_of_unique_genes.Rtab")
 boxplot(mydata, data=mydata, main="Number of unique genes",
-         xlab="Number of genomes", ylab="Number of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
+         xlab="No. of genomes", ylab="No. of genes",varwidth=TRUE, ylim=c(0,max(mydata)), outline=FALSE)
 
 mydata = read.table("blast_identity_frequency.Rtab")
 plot(mydata,main="Number of blastp hits with different percentage identity",  xlab="Blast percentage identity", ylab="No. blast results")

--- a/contrib/roary_plots/roary_plots.py
+++ b/contrib/roary_plots/roary_plots.py
@@ -84,8 +84,8 @@ if __name__ == "__main__":
     plt.hist(roary.sum(axis=1), roary.shape[1],
              histtype="stepfilled", alpha=.7)
 
-    plt.xlabel('Number of genomes')
-    plt.ylabel('Number of genes')
+    plt.xlabel('No. of genomes')
+    plt.ylabel('No. of genes')
 
     sns.despine(left=True,
                 bottom=True)
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                    ylabel=('',), xlabel=('',),
                    xlim=(-0.01,mdist+0.01),
                    axis=('off',),
-                   title=('parSNP tree\n(%d strains)'%roary.shape[1],),
+                   title=('Tree\n(%d strains)'%roary.shape[1],),
                    do_show=False,
                   )
         plt.savefig('pangenome_matrix.png')

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.5.3
+version = 3.5.4
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/External/Cdhit.pm
+++ b/lib/Bio/Roary/External/Cdhit.pm
@@ -30,6 +30,8 @@ has '_length_difference_cutoff'    => ( is => 'ro', isa => 'Num',  default  => 1
 has '_sequence_identity_threshold' => ( is => 'ro', isa => 'Num',  default  => 1 );
 has '_description_length'          => ( is => 'ro', isa => 'Int',  default  => 256 );
 has '_logging'                     => ( is => 'ro', isa => 'Str',  default  => '> /dev/null 2>&1' );
+has '_max_cpus'                    => ( is => 'ro', isa => 'Int',  default  => 40 );
+
 
 # Overload Role
 has 'memory_in_mb'  => ( is => 'ro', isa => 'Int',  lazy => 1, builder => '_build_memory_in_mb' );
@@ -70,11 +72,12 @@ sub _command_to_run {
 	
 	my $executable = $self->_find_exe([$self->exec, $self->alt_exec]);
 	
+	my $cpus = ($self->cpus > $self->_max_cpus) ? $self->_max_cpus :  $self->cpus;
     return join(
         ' ',
         (
             $executable,                        '-i', $self->input_file,                   '-o',
-            $self->output_base,                 '-T', $self->cpus,                         '-M',
+            $self->output_base,                 '-T', $cpus,                               '-M',
             $self->_max_available_memory_in_mb, '-g', $self->_use_most_similar_clustering, '-s',
             $self->_length_difference_cutoff,   '-d', $self->_description_length ,'-c', $self->_sequence_identity_threshold, 
             $self->_logging

--- a/lib/Bio/Roary/External/IterativeCdhit.pm
+++ b/lib/Bio/Roary/External/IterativeCdhit.pm
@@ -27,7 +27,7 @@ has 'output_combined_filename'        => ( is => 'ro', isa => 'Str', required =>
 has 'number_of_input_files'           => ( is => 'ro', isa => 'Int', required => 1 );
 has 'output_filtered_clustered_fasta' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'exec'                            => ( is => 'ro', isa => 'Str', default  => 'iterative_cdhit' );
-
+has '_max_cpus'                       => ( is => 'ro', isa => 'Int',  default  => 40 );
 # Overload Role
 has 'memory_in_mb' => ( is => 'ro', isa => 'Int', lazy => 1, builder => '_build_memory_in_mb' );
 
@@ -57,11 +57,13 @@ sub _build__max_available_memory_in_mb {
 
 sub _command_to_run {
     my ($self) = @_;
+	my $cpus = ($self->cpus > $self->_max_cpus) ? $self->_max_cpus :  $self->cpus;
+	
     return join(
         ' ',
         (
             $self->exec,                     '-c', $self->output_cd_hit_filename, '-m',
-            $self->output_combined_filename, '-n', $self->number_of_input_files, '--cpus', $self->cpus, '-f',
+            $self->output_combined_filename, '-n', $self->number_of_input_files, '--cpus', $cpus, '-f',
             $self->output_filtered_clustered_fasta
         )
     );

--- a/t/Bio/Roary/External/Cdhit.t
+++ b/t/Bio/Roary/External/Cdhit.t
@@ -26,4 +26,14 @@ unlink('output');
 unlink('output.clstr');
 unlink('output.bak.clstr');
 
+
+ok($obj = Bio::Roary::External::Cdhit->new(
+  input_file   => 't/data/some_fasta_file.fa',
+  output_base  => 'output',
+  exec         =>  $cwd.'/t/bin/dummy_cd-hit',
+  cpus         => 1000
+),'initialise object with lots of threads');
+is($obj->_command_to_run, $cwd.'/t/bin/dummy_cd-hit -i t/data/some_fasta_file.fa -o output -T 40 -M 1800 -g 1 -s 1 -d 256 -c 1 > /dev/null 2>&1', 'number of threads capped at a lower level');
+
+
 done_testing();


### PR DESCRIPTION
Its been reported that CD-hit crashes when its given more than ~50 threads. This PR introduces a hard limit of 40 to be on the safe side.
Also labels in the roary_plots.py & R scripts have been made consistent with the other figures.