### PR TITLE
roary_plots: new fields in roary output must be parsed away

### DIFF
--- a/contrib/roary_plots/roary.html
+++ b/contrib/roary_plots/roary.html
@@ -390,7 +390,7 @@ div#notebook {
 <span class="c"># Set index (group name)</span>
 <span class="n">roary</span><span class="o">.</span><span class="n">set_index</span><span class="p">(</span><span class="s">'Gene'</span><span class="p">,</span> <span class="n">inplace</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
 <span class="c"># Drop the other info columns</span>
-<span class="n">roary</span><span class="o">.</span><span class="n">drop</span><span class="p">(</span><span class="nb">list</span><span class="p">(</span><span class="n">roary</span><span class="o">.</span><span class="n">columns</span><span class="p">[:</span><span class="mi">10</span><span class="p">]),</span> <span class="n">axis</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">inplace</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
+<span class="n">roary</span><span class="o">.</span><span class="n">drop</span><span class="p">(</span><span class="nb">list</span><span class="p">(</span><span class="n">roary</span><span class="o">.</span><span class="n">columns</span><span class="p">[:</span><span class="mi">13</span><span class="p">]),</span> <span class="n">axis</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">inplace</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
 </pre></div>
 
 </div>

--- a/contrib/roary_plots/roary_plots.ipynb
+++ b/contrib/roary_plots/roary_plots.ipynb
@@ -103,7 +103,7 @@
     "# Set index (group name)\n",
     "roary.set_index('Gene', inplace=True)\n",
     "# Drop the other info columns\n",
-    "roary.drop(list(roary.columns[:10]), axis=1, inplace=True)"
+    "roary.drop(list(roary.columns[:13]), axis=1, inplace=True)"
    ]
   },
   {

--- a/contrib/roary_plots/roary_plots.py
+++ b/contrib/roary_plots/roary_plots.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # Set index (group name)
     roary.set_index('Gene', inplace=True)
     # Drop the other info columns
-    roary.drop(list(roary.columns[:10]), axis=1, inplace=True)
+    roary.drop(list(roary.columns[:13]), axis=1, inplace=True)
 
     # Transform it in a presence/absence matrix (1/0)
     roary.replace('.{2,100}', 1, regex=True, inplace=True)


### PR DESCRIPTION
The latest genes_presence_absence.csv format "breaks" the contributed script, because of the additional information columns.

This fix restores the functionality of the scripts.