### PR TITLE
get rid of warning message

### DIFF
--- a/lib/Bio/Roary/CommandLine/Common.pm
+++ b/lib/Bio/Roary/CommandLine/Common.pm
@@ -19,7 +19,7 @@ has 'version'                 => ( is => 'rw', isa => 'Bool', default => 0 );
 sub _build_logger
 {
     my ($self) = @_;
-    Log::Log4perl->easy_init(level => $ERROR);
+    Log::Log4perl->easy_init($ERROR);
     my $logger = get_logger();
     return $logger;
 }


### PR DESCRIPTION
On newer log4perl versions, current use of `easy_init()` leads to a
warning message being printed at runtime ("All arguments to easy_init
should be either an integer log level or a hash reference").
This patch changes this call to use the preferred syntax.