### PR TITLE
fix bug Can't exec /bin/sh: Argument list too long

### DIFF
--- a/lib/Bio/Roary/ParallelAllAgainstAllBlast.pm
+++ b/lib/Bio/Roary/ParallelAllAgainstAllBlast.pm
@@ -88,8 +88,14 @@ sub _combine_blast_results {
         Bio::Roary::Exceptions::FileNotFound->throw( error => "Cant find blast results: " . $output_file )
           unless ( -e $output_file );
     }
-    my $output_files_param = join( ' ', @{$output_files} );
-    system( "cat $output_files_param > " . $self->blast_results_file_name );
+    if ( -e $self->blast_results_file_name )
+    {
+        system( "rm " . $self->blast_results_file_name );
+    }
+    system( "touch " . $self->blast_results_file_name );
+    for my $output_file ( @{$output_files} ) {
+        system( "cat $output_file >> " . $self->blast_results_file_name );
+    }
     return 1;
 }
 


### PR DESCRIPTION
Hi Andrew,

I got the following error while running roary:

Can't exec "/bin/sh": Argument list too long at /tools/roary/lib/Bio/Roary/ParallelAllAgainstAllBlast.pm line 92, <GEN54> line 647671.
awk: fatal: cannot open file `_blast_results' for reading (No such file or directory)

Looking at that line (the bold one in the sub below):
sub _combine_blast_results {
    my ( $self, $output_files ) = @_;
    for my $output_file ( @{$output_files} ) {
        Bio::Roary::Exceptions::FileNotFound->throw( error => "Cant find blast results: " . $output_file )
          unless ( -e $output_file );
    }
    my $output_files_param = join( ' ', @{$output_files} );
    system( "cat $output_files_param > " . $self->blast_results_file_name );                                                                       
    return 1;
}

The error comes from the too long list in the shell while calling "cat".
So, I changed the sub above as below and it worked:

sub _combine_blast_results {
    my ( $self, $output_files ) = @_;
    for my $output_file ( @{$output_files} ) {
        Bio::Roary::Exceptions::FileNotFound->throw( error => "Cant find blast results: " . $output_file )
          unless ( -e $output_file );
    }
    if ( -e $self->blast_results_file_name )
    {                                                                                                                                              
        system( "rm " . $self->blast_results_file_name );
    }
    system( "touch " . $self->blast_results_file_name );
    for my $output_file ( @{$output_files} ) {
        system( "cat $output_file >> " . $self->blast_results_file_name );
    }
    return 1;
}

You may have a better fix then mine and it would be great if that fix can be integrated in the next version of Roary.

Thanks,
Tin
