### PR TITLE
Support latest version of blast

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,19 @@ Theres are a number of dependancies required for Roary, with instructions specif
 * Homebrew/Linuxbrew - OSX/Linux
 * Guix - Linux
 * Virtual Machine - OSX/Linux/Windows
-* Docker
+* Docker - OSX/Linux/Windows/Cloud
 * Installing from source - OSX/Linux
 
 If the installation fails please contact your system administrator. If you encounter a bug please let us know by emailing roary@sanger.ac.uk .
 
 ##Ubuntu/Debian
-### Ubuntu 16.04
-
+###Debian Testing
 ```
 sudo apt-get install roary
 ```
 
-###Ubuntu 14.04
-All the dependancies can be installed using apt and cpanm. Root permissions are required.
+###Ubuntu 14.04/16.04
+All the dependancies can be installed using apt and cpanm. Root permissions are required. Ubuntu 16.04 contains a package for Roary but it is frozen at v3.6.0.
 
 ```
 sudo apt-get install bedtools cd-hit ncbi-blast+ mcl parallel cpanminus prank mafft fasttree
@@ -67,7 +66,7 @@ ftp://ftp.sanger.ac.uk/pub/pathogens/pathogens-vm/pathogens-vm.latest.ova
 
 More importantly though, if your trying to do bioinformatics on Windows, your not going to get very far and you should seriously consider upgrading to Linux.
 
-##Docker
+##Docker - OSX/Linux/Windows/Cloud
 We have a docker container which gets automatically built from the latest version of Roary in Debian Med. To install it:
 
 ```

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Bio-Roary
-version = 3.7.1
+version = 3.8.0
 author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute

--- a/lib/Bio/Roary/External/Makeblastdb.pm
+++ b/lib/Bio/Roary/External/Makeblastdb.pm
@@ -49,7 +49,6 @@ sub _command_to_run {
             $self->exec,    
             '-in',      $self->fasta_file,       
             '-dbtype',  $self->_dbtype, 
-            '-parse_seqids',
             '-out',     $self->output_database, 
             '-logfile', $self->_logfile
         )

--- a/t/Bio/Roary/External/Makeblastdb.t
+++ b/t/Bio/Roary/External/Makeblastdb.t
@@ -20,7 +20,7 @@ ok($obj = Bio::Roary::External::Makeblastdb->new(
   mask_data       => 'masking_data_file'
 ),'initialise object');
 
-is($obj->_command_to_run, $cwd.'/t/bin/dummy_makeblastdb -in t/data/some_fasta_file.fa -dbtype prot -parse_seqids -out '.$obj->_working_directory->dirname().'/output_contigs -logfile /dev/null', 'Command constructed as expected');
+is($obj->_command_to_run, $cwd.'/t/bin/dummy_makeblastdb -in t/data/some_fasta_file.fa -dbtype prot -out '.$obj->_working_directory->dirname().'/output_contigs -logfile /dev/null', 'Command constructed as expected');
 ok($obj->run(), 'run dummy command');
 
 unlink("output_contigs.phr");

--- a/t/bin/dummy_makeblastdb
+++ b/t/bin/dummy_makeblastdb
@@ -7,7 +7,6 @@ GetOptions(
     'd|dbtype=s' => \$dbtype,
     'l|logfile=s' => \$logfile,
     'i|in=s' => \$in,
-    'parse_seqids' => \$parse_seqids,
     'mask_data=s' => \$mask_data,
 );
 

--- a/t/bin/dummy_segmasker
+++ b/t/bin/dummy_segmasker
@@ -7,7 +7,6 @@ GetOptions(
     'i|in=s'       => \$in,
     'infmt=s'      => \$infmt,
     'outfmt=s'     => \$outfmt,
-    'parse_seqids' => \$parse_seqids,
     'mask_data=s'  => \$mask_data,
 );
 


### PR DESCRIPTION
From blast+ 2.5.0 the functionality of parse_seqids changed when building databases (makeblastdb). This updated removes the flag.