### PR TITLE
Fix dependancy checking option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ bedtools cd-hit blast mcl GNUparallel prank mafft fasttree
 ```
 
 ## Ancient systems and versions of perl
-The code will not work with perl 5.8 or below (pre-modern perl). We no longer test against 5.10 (released 2007). If you're running a very old verison of Linux, you're also in trouble.
+The code will not work with perl 5.8 or below (pre-modern perl). We no longer test against 5.10 (released 2007) or 5.12 (released 2010). If you're running a very old verison of Linux, you're also in trouble.
 
 # Versions of software we test against
-* Perl 5.14, 5.16, 5.20, 5.24
-* cdhit 4.6.1
-* ncbi blast+ 2.4.0
+* Perl 5.14, 5.26
+* cdhit 4.6.8
+* ncbi blast+ 2.6.0
 * mcl 14-137
 * bedtools 2.27.1
-* prank 130410
-* GNU parallel 20130922, 20160722, 20150122
+* prank 140603
+* GNU parallel 20170822, 20160722
 * FastTree 2.1.9

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Andrew J. Page <ap13@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute
 copyright_year   = 2013
-version = 3.11.3
+version = 3.11.4
 main_module = lib/Bio/Roary.pm
 
 [MetaResources]

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -137,7 +137,7 @@ sub BUILD {
         $check_tools->check_all_tools;
         $self->logger->error( "Roary version " . $self->_version() );
 		
-		if( @{ $self->args } < 2 )
+		if( @{ $self->args } < 1 )
 		{
 			exit 0;
 		}

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -126,16 +126,21 @@ sub BUILD {
 		print $self->usage_text;
 		return;
 	}
+	
+    if ( defined($verbose) ) {
+        $self->verbose($verbose);
+        $self->logger->level(10000);
+    }
 
     if ($check_dependancies) {
         my $check_tools = Bio::Roary::External::CheckTools->new();
         $check_tools->check_all_tools;
         $self->logger->error( "Roary version " . $self->_version() );
-    }
-
-    if ( defined($verbose) ) {
-        $self->verbose($verbose);
-        $self->logger->level(10000);
+		
+		if( @{ $self->args } < 2 )
+		{
+			exit 0;
+		}
     }
 
     if ( @{ $self->args } < 2 ) {

--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -42,6 +42,7 @@ has 'cpus'                    => ( is => 'rw', isa => 'Int',  default => 1 );
 has 'output_multifasta_files' => ( is => 'rw', isa => 'Bool', default => 0 );
 has 'perc_identity'           => ( is => 'rw', isa => 'Num',  default => 95 );
 has 'dont_delete_files'       => ( is => 'rw', isa => 'Bool', default => 0 );
+has 'check_dependancies'      => ( is => 'rw', isa => 'Bool', default => 0 );
 has 'dont_create_rplots'      => ( is => 'rw', isa => 'Bool', default => 1 );
 has 'dont_run_qc'             => ( is => 'rw', isa => 'Bool', default => 0 );
 has 'dont_split_groups'       => ( is => 'rw', isa => 'Bool', default => 0 );
@@ -132,14 +133,15 @@ sub BUILD {
         $self->logger->level(10000);
     }
 
-    if ($check_dependancies) {
+	$self->check_dependancies($check_dependancies) if ( defined($check_dependancies) );
+    if ($self->check_dependancies) {
         my $check_tools = Bio::Roary::External::CheckTools->new();
         $check_tools->check_all_tools;
         $self->logger->error( "Roary version " . $self->_version() );
 		
 		if( @{ $self->args } < 1 )
 		{
-			exit 0;
+			return;
 		}
     }
 
@@ -265,7 +267,7 @@ sub _setup_output_directory {
 sub run {
     my ($self) = @_;
 
-	return if($self->version || $self->help);
+	return if($self->version || $self->help || ($self->check_dependancies && @{$self->fasta_files} < 1) );
 
     $self->_setup_output_directory;
 


### PR DESCRIPTION
When passing in '-a' with no files, it exits gracefully. If you pass in input files, it performs the dependancy checks and it continues to run as normal.

https://github.com/sanger-pathogens/Roary/issues/269