### PR TITLE
Update roary_plots from .ix to .loc

### DIFF
--- a/contrib/roary_plots/roary_plots.py
+++ b/contrib/roary_plots/roary_plots.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
 
     # Sort the matrix by the sum of strains presence
     idx = roary.sum(axis=1).sort_values(ascending=False).index
-    roary_sorted = roary.ix[idx]
+    roary_sorted = roary.loc[idx]
 
     # Pangenome frequency plot
     plt.figure(figsize=(7, 5))


### PR DESCRIPTION
Since 0.20.1 .loc is the preferred index lookup method instead of .ix
https://pandas.pydata.org/pandas-docs/version/0.20/whatsnew.html#deprecate-ix