### PR TITLE
Fix cd-hit version check regexp

### DIFF
--- a/lib/Bio/Roary/External/CheckTools.pm
+++ b/lib/Bio/Roary/External/CheckTools.pm
@@ -92,12 +92,12 @@ my %tools = (
 my %cdhit_tools = (
     'cdhit' => {
         GETVER => "cdhit -h | grep 'CD-HIT version'",
-        REGEXP => qr/version ($BIDEC) /,
+        REGEXP => qr/version\s+($BIDEC)/i,
         MINVER => "4.6",
     },
     'cd-hit' => {
         GETVER => "cd-hit -h | grep 'CD-HIT version'",
-        REGEXP => qr/version ($BIDEC) /,
+        REGEXP => qr/version\s+($BIDEC)i/,
         MINVER => "4.6",
     }
 );


### PR DESCRIPTION
Needed for newer versions of cd-hit