### PR TITLE
Fixed version check for cd-hit

### DIFF
--- a/lib/Bio/Roary/External/CheckTools.pm
+++ b/lib/Bio/Roary/External/CheckTools.pm
@@ -97,7 +97,7 @@ my %cdhit_tools = (
     },
     'cd-hit' => {
         GETVER => "cd-hit -h | grep 'CD-HIT version'",
-        REGEXP => qr/version\s+($BIDEC)i/,
+        REGEXP => qr/version\s+($BIDEC)/i,
         MINVER => "4.6",
     }
 );


### PR DESCRIPTION
The regex searching for the version of `cd-hit` contained an error when compared to the regex for `cdhit`.