### PR TITLE
fixed error by old pandas version

### DIFF
--- a/contrib/roary_plots/roary_plots.ipynb
+++ b/contrib/roary_plots/roary_plots.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "# Sort the matrix by the sum of strains presence\n",
     "idx = roary.sum(axis=1).sort_values(ascending=False).index\n",
-    "roary_sorted = roary.ix[idx]"
+    "roary_sorted = roary.loc[idx]"
    ]
   },
   {
@@ -806,7 +806,7 @@
     "    ax1.axis('off')\n",
     "\n",
     "    ax = fig.add_subplot(1,2,1)\n",
-    "    ax=plt.subplot2grid((1,40), (0, 0), colspan=10, axisbg='white')\n",
+    "    ax=plt.subplot2grid((1,40), (0, 0), colspan=10, facecolor='white')\n",
     "\n",
     "    fig.subplots_adjust(wspace=0, hspace=0)\n",
     "\n",


### PR DESCRIPTION
newer pandas version use `.loc` rather than `.ix`
see: https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.DataFrame.ix.html fore more info.

same goes for matplotlib from `axisbg` to `facecolor`