### PR TITLE
Fix not passing enough memory to cd-hit

### DIFF
--- a/lib/Bio/Roary/External/Cdhit.pm
+++ b/lib/Bio/Roary/External/Cdhit.pm
@@ -48,7 +48,7 @@ sub _build_memory_in_mb
     $memory_required = int($memory_required/1000000);
     # Give it bucket loads of memory for the worst case scenario
     $memory_required *= 5;
-    $memory_required = 2000 if($memory_required < 2000);
+    $memory_required = 2225 if($memory_required < 2225);
   }
 
   return $memory_required;


### PR DESCRIPTION
cd-hit requires at least 2000 mb of memory to be passed to it through the -M flag. The Cdhit.pm script reserves this amount for the job runner, but sets -M to 0.9\*2000 = 1800 mb, which causes cd-hit to fail. This commit fixes the issue by allocating more memory in total (2225 mb => 0.9\*2225 = 2002 mb).