### PR TITLE
Set value for "allow_paralogs" attribute

### DIFF
--- a/lib/Bio/Roary/CommandLine/Roary.pm
+++ b/lib/Bio/Roary/CommandLine/Roary.pm
@@ -201,6 +201,7 @@ sub BUILD {
     }
     $self->dont_delete_files($dont_delete_files) if ( defined($dont_delete_files) );
     $self->dont_split_groups($dont_split_groups) if ( defined($dont_split_groups) );
+    $self->allow_paralogs($allow_paralogs)       if ( defined($allow_paralogs) );
     $self->dont_create_rplots(0)                 if ( defined($create_rplots) );
     $self->verbose_stats($verbose_stats)         if ( defined $verbose_stats );
     $self->translation_table($translation_table) if ( defined($translation_table) );


### PR DESCRIPTION
The `--allow_paralogs` or `-ap` flag was not working because the attribute was not set in the `lib/Bio/Roary/CommandLine/Roary.pm` file. I have added this feature and verified that it is now working correctly. This might also resolve #462 .